### PR TITLE
Fix valgrind bugs

### DIFF
--- a/src/include/optimizer/stats/hll.h
+++ b/src/include/optimizer/stats/hll.h
@@ -42,7 +42,8 @@ class HLL {
 
   uint64_t Hash(type::Value& value) {
     uint64_t hash[2];
-    const char* raw_value = value.ToString().c_str();
+    std::string value_str = value.ToString();
+    const char* raw_value = value_str.c_str();
     MurmurHash3_x64_128(raw_value, (uint64_t)strlen(raw_value), 0, hash);
     return hash[0];
   }

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -49,6 +49,8 @@ class StatsStorage {
 
   StatsStorage();
 
+  ~StatsStorage();
+
   /* Functions for managing stats table and schema */
 
   void CreateStatsCatalog();
@@ -86,6 +88,8 @@ class StatsStorage {
   void CollectStatsForAllTables();
 
  private:
+  std::unique_ptr<type::AbstractPool> pool_;
+
   std::unique_ptr<storage::Tuple> GetColumnStatsTuple(
     const catalog::Schema *schema, oid_t database_id, oid_t table_id,
     oid_t column_id, int num_row, double cardinality, double frac_null,

--- a/src/include/optimizer/stats/tuple_sampler.h
+++ b/src/include/optimizer/stats/tuple_sampler.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "type/types.h"
+#include "type/ephemeral_pool.h"
 
 namespace peloton {
 namespace storage {
@@ -31,7 +32,9 @@ namespace optimizer {
 class TupleSampler {
  public:
   TupleSampler(storage::DataTable *table)
-                : table{table} {}
+                : table{table} {
+    pool_.reset(new type::EphemeralPool());
+  }
 
   size_t AcquireSampleTuples(size_t target_sample_count);
   bool GetTupleInTileGroup(storage::TileGroup *tile_group, size_t tuple_offset,
@@ -43,6 +46,8 @@ class TupleSampler {
   void InitState();
   bool HasNext();
   int GetNext();
+
+  std::unique_ptr<type::AbstractPool> pool_;
 
   storage::DataTable *table;
 

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -26,8 +26,13 @@ StatsStorage *StatsStorage::GetInstance(void) {
 }
 
 StatsStorage::StatsStorage() {
+  pool_.reset(new type::EphemeralPool());
   CreateStatsCatalog();
   CreateSamplesDatabase();
+}
+
+StatsStorage::~StatsStorage() {
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(SAMPLES_DB_NAME, nullptr);
 }
 
 void StatsStorage::CreateStatsCatalog() {
@@ -185,9 +190,9 @@ std::unique_ptr<storage::Tuple> StatsStorage::GetColumnStatsTuple(
   tuple->SetValue(3, val_num_row, nullptr);
   tuple->SetValue(4, val_cardinality, nullptr);
   tuple->SetValue(5, val_frac_null, nullptr);
-  tuple->SetValue(6, val_common_val, nullptr);
+  tuple->SetValue(6, val_common_val, pool_.get());
   tuple->SetValue(7, val_common_freq, nullptr);
-  tuple->SetValue(8, val_hist_bounds, nullptr);
+  tuple->SetValue(8, val_hist_bounds, pool_.get());
   return std::move(tuple);
 }
 

--- a/src/optimizer/stats/tuple_sampler.cpp
+++ b/src/optimizer/stats/tuple_sampler.cpp
@@ -117,7 +117,7 @@ bool TupleSampler::GetTupleInTileGroup(storage::TileGroup *tile_group,
     for (oid_t tile_column_itr = 0; tile_column_itr < tile_column_count;
          tile_column_itr++) {
       type::Value val = (tile_tuple.GetValue(tile_column_itr));
-      tuple->SetValue(tuple_column_itr, val);
+      tuple->SetValue(tuple_column_itr, val, pool_.get());
       tuple_column_itr++;
     }
   }


### PR DESCRIPTION
Fix two bugs shown in valgrind:
1. Fix memory leak of StatsStorage and TupleSampler by adding memory pool.
2. Fix valgrind 'invalid read of size 1' bug in `hll.h`