### PR TITLE
Support multiple common val-freqs. Add a ColumnStatsSet wrapper.

### DIFF
--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -32,7 +32,6 @@
 #pragma once
 
 #include "catalog/abstract_catalog.h"
-#include "statistics/query_metric.h"
 
 #define COLUMN_STATS_CATALOG_NAME "pg_column_stats"
 

--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -56,7 +56,8 @@ class ColumnStatsCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   bool InsertColumnStats(oid_t database_id, oid_t table_id, oid_t column_id,
                          int num_row, double cardinality, double frac_null,
-                         std::string most_common_vals, double most_common_freqs,
+                         std::string most_common_vals,
+                         std::string most_common_freqs,
                          std::string histogram_bounds, type::AbstractPool *pool,
                          concurrency::Transaction *txn);
   bool DeleteColumnStats(oid_t database_id, oid_t table_id, oid_t column_id,

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -44,22 +44,24 @@ class StatsStorage {
 
   /* Functions for adding, updating and quering stats */
 
-  void InsertOrUpdateTableStats(storage::DataTable *table, TableStats *table_stats,
-                             concurrency::Transaction *txn = nullptr);
+  void InsertOrUpdateTableStats(storage::DataTable *table,
+                                TableStats *table_stats,
+                                concurrency::Transaction *txn = nullptr);
 
   void InsertOrUpdateColumnStats(oid_t database_id, oid_t table_id,
-                              oid_t column_id, int num_row, double cardinality,
-                              double frac_null, std::string most_common_vals,
-                              double most_common_freqs,
-                              std::string histogram_bounds,
-                              concurrency::Transaction *txn = nullptr);
+                                 oid_t column_id, int num_row,
+                                 double cardinality, double frac_null,
+                                 std::string most_common_vals,
+                                 double most_common_freqs,
+                                 std::string histogram_bounds,
+                                 concurrency::Transaction *txn = nullptr);
 
   std::unique_ptr<std::vector<type::Value>> GetColumnStatsByID(
       oid_t database_id, oid_t table_id, oid_t column_id);
 
   /* Functions for triggerring stats collection */
 
-  ResultType AnalyzeStatsForAllTables();
+  ResultType AnalyzeStatsForAllTables(concurrency::Transaction *txn = nullptr);
 
   ResultType AnalyzeStatsForTable(storage::DataTable *table,
                                   concurrency::Transaction *txn = nullptr);

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -31,6 +31,8 @@ namespace optimizer {
 
 using ValueFrequencyPair = std::pair<type::Value, double>;
 
+class ColumnStatsSet;
+
 class StatsStorage {
  public:
   // Global Singleton
@@ -52,12 +54,13 @@ class StatsStorage {
                                  oid_t column_id, int num_row,
                                  double cardinality, double frac_null,
                                  std::string most_common_vals,
-                                 double most_common_freqs,
+                                 std::string most_common_freqs,
                                  std::string histogram_bounds,
                                  concurrency::Transaction *txn = nullptr);
 
-  std::unique_ptr<std::vector<type::Value>> GetColumnStatsByID(
-      oid_t database_id, oid_t table_id, oid_t column_id);
+  std::unique_ptr<ColumnStatsSet> GetColumnStatsByID(oid_t database_id,
+                                                     oid_t table_id,
+                                                     oid_t column_id);
 
   /* Functions for triggerring stats collection */
 
@@ -73,6 +76,9 @@ class StatsStorage {
   std::unique_ptr<type::AbstractPool> pool_;
 
   std::string ConvertDoubleArrayToString(std::vector<double> &double_array) {
+    if (double_array.size() == 0) {
+      return std::string();
+    }
     std::stringstream ss;
     for (size_t i = 0; i < double_array.size(); ++i) {
       if (i != 0) {
@@ -98,6 +104,50 @@ class StatsStorage {
 
     return double_array;
   }
+
+  std::pair<std::string, std::string> ConvertValueFreqArrayToStrings(
+      std::vector<ValueFrequencyPair> &val_freqs) {
+    size_t array_size = val_freqs.size();
+    if (array_size == 0) {
+      return std::make_pair("", "");
+    }
+    auto type_id = val_freqs[0].first.GetTypeId();
+    if (type_id == type::Type::VARBINARY || type_id == type::Type::VARCHAR) {
+      return std::make_pair("", "");
+    }
+    std::stringstream ss_value;
+    std::stringstream ss_freq;
+    for (size_t i = 0; i < array_size; ++i) {
+      if (i != 0) {
+        ss_value << ",";
+        ss_freq << ",";
+      }
+      ss_value << val_freqs[i].first.ToString();
+      ss_freq << val_freqs[i].second;
+    }
+    return std::make_pair(ss_value.str(), ss_freq.str());
+  }
+};
+
+class ColumnStatsSet {
+ public:
+  ColumnStatsSet(size_t num_row, double cardinality, double frac_null,
+                 std::vector<double> most_common_vals,
+                 std::vector<double> most_common_freqs,
+                 std::vector<double> histogram_bounds)
+      : num_row(num_row),
+        cardinality(cardinality),
+        frac_null(frac_null),
+        most_common_vals(most_common_vals),
+        most_common_freqs(most_common_freqs),
+        histogram_bounds(histogram_bounds) {}
+
+  size_t num_row;
+  double cardinality;
+  double frac_null;
+  std::vector<double> most_common_vals;
+  std::vector<double> most_common_freqs;
+  std::vector<double> histogram_bounds;
 };
 }
 }

--- a/test/optimizer/stats_storage_test.cpp
+++ b/test/optimizer/stats_storage_test.cpp
@@ -98,16 +98,20 @@ void VerifyAndPrintColumnStats(storage::DataTable *data_table,
 
   // Print out all four column stats.
   for (int column_id = 0; column_id < expect_tuple_count; ++column_id) {
-    // storage::Tuple tile_tuple(&schema, tile->GetTupleLocation(column_id));
-    // LOG_DEBUG("Tuple Info: %s", tile_tuple.GetInfo().c_str());
-
-    // Get column stats using the GetColumnStatsByID function and compare the
-    // results.
     auto column_stats = stats_storage->GetColumnStatsByID(
         data_table->GetDatabaseOid(), data_table->GetOid(), column_id);
-    for (auto value : *(column_stats.get())) {
-      LOG_DEBUG("Value: %s", value.GetInfo().c_str());
-    }
+    LOG_DEBUG("num_row: %lu", column_stats->num_row);
+    LOG_DEBUG("cardinality: %lf", column_stats->cardinality);
+    LOG_DEBUG("frac_null: %lf", column_stats->frac_null);
+    auto most_common_vals = column_stats->most_common_vals;
+    auto most_common_freqs = column_stats->most_common_freqs;
+    auto hist_bounds = column_stats->histogram_bounds;
+    // for(size_t i = 0; i < most_common_vals.size(); ++i) {
+    //   LOG_DEBUG("(%lf, %lf)", most_common_vals[i], most_common_freqs[i]);
+    // }
+    // for(size_t i = 0; i < hist_bounds.size(); ++i) {
+    //   LOG_DEBUG("[%lf]", hist_bounds[i]);
+    // }
   }
 }
 
@@ -140,7 +144,7 @@ TEST_F(StatsStorageTests, InsertAndGetColumnStatsTest) {
   double cardinality = 8;
   double frac_null = 0.56;
   std::string most_common_vals = "12";
-  double most_common_freqs = 3;
+  std::string most_common_freqs = "3";
   std::string histogram_bounds = "1,5,7";
 
   stats_storage->InsertOrUpdateColumnStats(
@@ -152,22 +156,10 @@ TEST_F(StatsStorageTests, InsertAndGetColumnStatsTest) {
 
   // Check the result
   EXPECT_NE(column_stats_ptr, nullptr);
-  std::vector<type::Value> column_stats = *(column_stats_ptr.get());
-  for (auto value : *(column_stats_ptr.get())) {
-    LOG_DEBUG("Value: %s", value.GetInfo().c_str());
-  }
-  EXPECT_TRUE(column_stats[0].CompareEquals(
-      type::ValueFactory::GetIntegerValue(num_row)));
-  EXPECT_TRUE(column_stats[1].CompareEquals(
-      type::ValueFactory::GetDecimalValue(cardinality)));
-  EXPECT_TRUE(column_stats[2].CompareEquals(
-      type::ValueFactory::GetDecimalValue(frac_null)));
-  EXPECT_TRUE(column_stats[3].CompareEquals(
-      type::ValueFactory::GetVarcharValue(most_common_vals)));
-  EXPECT_TRUE(column_stats[4].CompareEquals(
-      type::ValueFactory::GetDecimalValue(most_common_freqs)));
-  EXPECT_TRUE(column_stats[5].CompareEquals(
-      type::ValueFactory::GetVarcharValue(histogram_bounds)));
+
+  EXPECT_EQ(column_stats_ptr->num_row, num_row);
+  EXPECT_EQ(column_stats_ptr->cardinality, cardinality);
+  EXPECT_EQ(column_stats_ptr->frac_null, frac_null);
 
   // Should return nullptr
   auto column_stats_ptr2 =
@@ -188,14 +180,14 @@ TEST_F(StatsStorageTests, UpdateColumnStatsTest) {
   double cardinality_0 = 8;
   double frac_null_0 = 0.56;
   std::string most_common_vals_0 = "12";
-  double most_common_freqs_0 = 3;
+  std::string most_common_freqs_0 = "3";
   std::string histogram_bounds_0 = "1,5,7";
 
   int num_row_1 = 20;
   double cardinality_1 = 16;
   double frac_null_1 = 1.56;
   std::string most_common_vals_1 = "24";
-  double most_common_freqs_1 = 6;
+  std::string most_common_freqs_1 = "6";
   std::string histogram_bounds_1 = "2,10,14";
 
   stats_storage->InsertOrUpdateColumnStats(
@@ -210,22 +202,10 @@ TEST_F(StatsStorageTests, UpdateColumnStatsTest) {
 
   // Check the result
   EXPECT_NE(column_stats_ptr, nullptr);
-  std::vector<type::Value> column_stats = *(column_stats_ptr.get());
-  for (auto value : *(column_stats_ptr.get())) {
-    LOG_DEBUG("Value: %s", value.GetInfo().c_str());
-  }
-  EXPECT_TRUE(column_stats[0].CompareEquals(
-      type::ValueFactory::GetIntegerValue(num_row_1)));
-  EXPECT_TRUE(column_stats[1].CompareEquals(
-      type::ValueFactory::GetDecimalValue(cardinality_1)));
-  EXPECT_TRUE(column_stats[2].CompareEquals(
-      type::ValueFactory::GetDecimalValue(frac_null_1)));
-  EXPECT_TRUE(column_stats[3].CompareEquals(
-      type::ValueFactory::GetVarcharValue(most_common_vals_1)));
-  EXPECT_TRUE(column_stats[4].CompareEquals(
-      type::ValueFactory::GetDecimalValue(most_common_freqs_1)));
-  EXPECT_TRUE(column_stats[5].CompareEquals(
-      type::ValueFactory::GetVarcharValue(histogram_bounds_1)));
+
+  EXPECT_EQ(column_stats_ptr->num_row, num_row_1);
+  EXPECT_EQ(column_stats_ptr->cardinality, cardinality_1);
+  EXPECT_EQ(column_stats_ptr->frac_null, frac_null_1);
 }
 
 // TEST_F(StatsStorageTests, AnalyzeStatsForAllTablesTest) {


### PR DESCRIPTION
This PR contains some fixes and improvements over `StatsStorage`.

1. Fix bugs for `AnalyzeStatsForAllTables`. Add one test for it.
2. Support multiple common val-freqs pairs for numbers. `VARCHAR` and `VARBINARY` types are not supported.
3. In the `GetColumnStatsByID` function, convert the `VARCHAR` type back to double array.
4. In the `GetColumnStatsByID` function, store all column stats in the `ColumnStatsSet` wrapper as the return value.