### PR TITLE
Add more interfaces for TableStats.

### DIFF
--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -59,7 +59,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
                          std::string most_common_vals,
                          std::string most_common_freqs,
                          std::string histogram_bounds, std::string column_name,
-                         type::AbstractPool *pool,
+                         bool has_index, type::AbstractPool *pool,
                          concurrency::Transaction *txn);
   bool DeleteColumnStats(oid_t database_id, oid_t table_id, oid_t column_id,
                          concurrency::Transaction *txn);
@@ -83,6 +83,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
     MOST_COMMON_FREQS = 7,
     HISTOGRAM_BOUNDS = 8,
     COLUMN_NAME = 9,
+    HAS_INDEX = 10,
     // Add new columns here in creation order
   };
 
@@ -94,6 +95,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
     COMMON_FREQS_OFF = 4,
     HIST_BOUNDS_OFF = 5,
     COLUMN_NAME_OFF = 6,
+    HAS_INDEX_OFF = 7,
   };
 
  private:

--- a/src/include/optimizer/stats/column_stats.h
+++ b/src/include/optimizer/stats/column_stats.h
@@ -24,7 +24,7 @@ namespace optimizer {
 class ColumnStats {
  public:
   ColumnStats(oid_t database_id, oid_t table_id, oid_t column_id,
-              const std::string column_name, size_t num_rows,
+              const std::string column_name, bool has_index, size_t num_rows,
               double cardinality, double frac_null,
               std::vector<double> most_common_vals,
               std::vector<double> most_common_freqs,
@@ -33,6 +33,7 @@ class ColumnStats {
         table_id(table_id),
         column_id(column_id),
         column_name(column_name),
+        has_index(has_index),
         num_rows(num_rows),
         cardinality(cardinality),
         frac_null(frac_null),
@@ -45,6 +46,7 @@ class ColumnStats {
   oid_t table_id;
   oid_t column_id;
   std::string column_name;
+  bool has_index;
 
   size_t num_rows;
   double cardinality;

--- a/src/include/optimizer/stats/column_stats_collector.h
+++ b/src/include/optimizer/stats/column_stats_collector.h
@@ -60,6 +60,10 @@ class ColumnStatsCollector {
 
   inline std::string GetColumnName() { return column_name_; }
 
+  inline void SetColumnIndexed() { has_index_ = true; }
+
+  inline bool HasIndex() { return has_index_; }
+
  private:
   const oid_t database_id_;
   const oid_t table_id_;
@@ -70,6 +74,8 @@ class ColumnStatsCollector {
   Histogram hist_;
   CountMinSketch sketch_;
   TopKElements topk_;
+
+  bool has_index_ = false;
 
   size_t null_count_ = 0;
   size_t total_count_ = 0;

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -54,7 +54,8 @@ class StatsStorage {
       oid_t database_id, oid_t table_id, oid_t column_id, int num_rows,
       double cardinality, double frac_null, std::string most_common_vals,
       std::string most_common_freqs, std::string histogram_bounds,
-      std::string column_name, concurrency::Transaction *txn = nullptr);
+      std::string column_name, bool has_index = false,
+      concurrency::Transaction *txn = nullptr);
 
   std::shared_ptr<ColumnStats> GetColumnStatsByID(oid_t database_id,
                                                   oid_t table_id,

--- a/src/include/optimizer/stats/table_stats.h
+++ b/src/include/optimizer/stats/table_stats.h
@@ -18,6 +18,8 @@
 namespace peloton {
 namespace optimizer {
 
+#define DEFAULT_CARDINALITY 1
+
 class ColumnStats;
 
 //===--------------------------------------------------------------------===//
@@ -32,7 +34,15 @@ class TableStats {
   TableStats(size_t num_rows,
              std::vector<std::shared_ptr<ColumnStats>> col_stats_list);
 
-  size_t num_rows;
+  void UpdateNumRows(size_t new_num_rows);
+
+  bool HasIndex(const std::string column_name);
+
+  bool HasPrimaryIndex(const std::string column_name);
+
+  double GetCardinality(const std::string column_name);
+
+  void ClearColumnStats();
 
   bool HasColumnStats(std::string col_name);
 
@@ -41,6 +51,8 @@ class TableStats {
   bool AddColumnStats(std::shared_ptr<ColumnStats> col_stats);
 
   bool RemoveColumnStats(std::string col_name);
+
+  size_t num_rows;
 
  private:
   std::unordered_map<std::string, std::shared_ptr<ColumnStats>>

--- a/src/optimizer/stats/table_stats.cpp
+++ b/src/optimizer/stats/table_stats.cpp
@@ -24,6 +24,30 @@ TableStats::TableStats(size_t num_rows,
   }
 }
 
+void TableStats::UpdateNumRows(size_t new_num_rows) { num_rows = new_num_rows; }
+
+bool TableStats::HasIndex(const std::string column_name) {
+  auto column_stats = GetColumnStats(column_name);
+  if (column_stats == nullptr) {
+    return false;
+  }
+  return column_stats->has_index;
+}
+
+bool TableStats::HasPrimaryIndex(const std::string column_name) {
+  return HasIndex(column_name);
+}
+
+double TableStats::GetCardinality(const std::string column_name) {
+  auto column_stats = GetColumnStats(column_name);
+  if (column_stats == nullptr) {
+    return DEFAULT_CARDINALITY;
+  }
+  return column_stats->cardinality;
+}
+
+void TableStats::ClearColumnStats() { col_name_to_stats_map_.clear(); }
+
 bool TableStats::HasColumnStats(std::string col_name) {
   auto it = col_name_to_stats_map_.find(col_name);
   if (it == col_name_to_stats_map_.end()) {

--- a/src/optimizer/stats/table_stats_collector.cpp
+++ b/src/optimizer/stats/table_stats_collector.cpp
@@ -73,6 +73,12 @@ void TableStatsCollector::InitColumnStatsCollectors() {
         schema_->GetColumn(column_id).GetName()));
     column_stats_collectors_.push_back(std::move(colstats));
   }
+
+  // Set indexes in the column stats collectors.
+  for (auto& column_set : table_->GetIndexColumns()) {
+    auto column_id = *(column_set.begin());
+    column_stats_collectors_[column_id]->SetColumnIndexed();
+  }
 }
 
 ColumnStatsCollector* TableStatsCollector::GetColumnStats(oid_t column_id) {

--- a/test/optimizer/table_stats_test.cpp
+++ b/test/optimizer/table_stats_test.cpp
@@ -29,34 +29,68 @@ using namespace optimizer;
 
 class TableStatsTests : public PelotonTest {};
 
-std::shared_ptr<ColumnStats> CreateTestColumnStats(oid_t database_id,
-                                                   oid_t table_id,
-                                                   oid_t column_id,
-                                                   std::string column_name) {
-  return std::shared_ptr<ColumnStats>(new ColumnStats(
-      database_id, table_id, column_id, column_name, 0, 0, 0, {}, {}, {}));
+std::shared_ptr<ColumnStats> CreateTestColumnStats(
+    oid_t database_id, oid_t table_id, oid_t column_id, std::string column_name,
+    bool has_index, double cardinality = 10) {
+  return std::shared_ptr<ColumnStats>(
+      new ColumnStats(database_id, table_id, column_id, column_name, has_index,
+                      0, cardinality, 0, {}, {}, {}));
 }
 
 // Test the constructors of TableStats
-// Test the Get/Add/Remove functions of TableStats
-TEST_F(TableStatsTests, ConstructorTests) {
+// Test the Get function of TableStats
+TEST_F(TableStatsTests, BaiscTests) {
   TableStats table_stats0;
   EXPECT_EQ(table_stats0.num_rows, 0);
 
   TableStats table_stats1(10);
   EXPECT_EQ(table_stats1.num_rows, 10);
 
-  auto col_stats0 = CreateTestColumnStats(0, 0, 0, "col0");
-  auto col_stats1 = CreateTestColumnStats(1, 1, 1, "col1");
-  auto col_stats2 = CreateTestColumnStats(2, 2, 2, "col2");
+  auto col_stats0 = CreateTestColumnStats(0, 0, 0, "col0", true, 10);
+  auto col_stats1 = CreateTestColumnStats(1, 1, 1, "col1", false, 20);
 
   TableStats table_stats2(20, {col_stats0, col_stats1});
   EXPECT_EQ(table_stats2.num_rows, 20);
 
   auto col_stats_result0 = table_stats2.GetColumnStats("col0");
   EXPECT_EQ(col_stats_result0->database_id, 0);
+  EXPECT_EQ(col_stats_result0->has_index, true);
   auto col_stats_result1 = table_stats2.GetColumnStats("col1");
   EXPECT_EQ(col_stats_result1->database_id, 1);
+  EXPECT_EQ(col_stats_result1->has_index, false);
+
+  EXPECT_EQ(table_stats2.HasIndex("col0"), true);
+  EXPECT_EQ(table_stats2.HasIndex("col1"), false);
+  EXPECT_EQ(table_stats2.HasIndex("col3"), false);
+
+  EXPECT_EQ(table_stats2.GetCardinality("col0"), 10);
+  EXPECT_EQ(table_stats2.GetCardinality("col1"), 20);
+}
+
+// Test all update functions of TableStats, including UpdateNumRows,
+// AddColumnStats, RemoveColumnStats and ClearColumnStats.
+TEST_F(TableStatsTests, UpdateTests) {
+  auto col_stats0 = CreateTestColumnStats(0, 0, 0, "col0", true, 10);
+  auto col_stats1 = CreateTestColumnStats(1, 1, 1, "col1", false, 20);
+  auto col_stats2 = CreateTestColumnStats(2, 2, 2, "col2", true, 30);
+
+  TableStats table_stats(20, {col_stats0, col_stats1});
+
+  table_stats.UpdateNumRows(30);
+  EXPECT_EQ(table_stats.num_rows, 30);
+
+  EXPECT_EQ(table_stats.GetColumnStats("col2"), nullptr);
+  table_stats.AddColumnStats(col_stats2);
+  EXPECT_NE(table_stats.GetColumnStats("col2"), nullptr);
+  EXPECT_EQ(table_stats.HasIndex("col2"), true);
+  EXPECT_EQ(table_stats.GetCardinality("col2"), 30);
+
+  table_stats.RemoveColumnStats("col0");
+  EXPECT_EQ(table_stats.GetColumnStats("col0"), nullptr);
+
+  table_stats.ClearColumnStats();
+  EXPECT_EQ(table_stats.GetColumnStats("col1"), nullptr);
+  EXPECT_EQ(table_stats.GetColumnStats("col2"), nullptr);
 }
 
 } /* namespace test */


### PR DESCRIPTION
This PR adds the following interfaces for `TableStats`:
* `void UpdateNumRows(size_t new_num_rows);`
* `bool HasIndex(const std::string column_name);`
* `bool HasPrimaryIndex(const std::string column_name);`
* `double GetCardinality(const std::string column_name);`
* `void ClearColumnStats();`