### PR TITLE
Add GetTableStats interfaces.

### DIFF
--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -70,6 +70,11 @@ class ColumnStatsCatalog : public AbstractCatalog {
   std::unique_ptr<std::vector<type::Value>> GetColumnStats(
       oid_t database_id, oid_t table_id, oid_t column_id,
       concurrency::Transaction *txn);
+
+  size_t GetTableStats(
+      oid_t database_id, oid_t table_id, concurrency::Transaction *txn,
+      std::map<oid_t, std::unique_ptr<std::vector<type::Value>>> &
+          column_stats_map);
   // TODO: add more if needed
 
   enum ColumnId {
@@ -103,6 +108,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
 
   enum IndexId {
     SECONDARY_KEY_0 = 0,
+    SECONDARY_KEY_1 = 1,
     // Add new indexes here in creation order
   };
 };

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -32,6 +32,7 @@ namespace optimizer {
 using ValueFrequencyPair = std::pair<type::Value, double>;
 
 class ColumnStats;
+class TableStats;
 
 class StatsStorage {
  public:
@@ -61,6 +62,11 @@ class StatsStorage {
                                                   oid_t table_id,
                                                   oid_t column_id);
 
+  std::shared_ptr<TableStats> GetTableStats(oid_t database_id, oid_t table_id);
+
+  std::shared_ptr<TableStats> GetTableStats(oid_t database_id, oid_t table_id,
+                                            std::vector<oid_t> column_ids);
+
   /* Functions for triggerring stats collection */
 
   ResultType AnalyzeStatsForAllTables(concurrency::Transaction *txn = nullptr);
@@ -73,6 +79,10 @@ class StatsStorage {
 
  private:
   std::unique_ptr<type::AbstractPool> pool_;
+
+  std::shared_ptr<ColumnStats> ConvertVectorToColumnStats(
+      oid_t database_id, oid_t table_id, oid_t column_id,
+      std::unique_ptr<std::vector<type::Value>> &column_stats_vector);
 
   std::string ConvertDoubleArrayToString(std::vector<double> &double_array) {
     if (double_array.size() == 0) {

--- a/src/include/optimizer/stats/table_stats.h
+++ b/src/include/optimizer/stats/table_stats.h
@@ -32,7 +32,9 @@ class TableStats {
   TableStats(size_t num_rows) : num_rows(num_rows) {}
 
   TableStats(size_t num_rows,
-             std::vector<std::shared_ptr<ColumnStats>> col_stats_list);
+             std::vector<std::shared_ptr<ColumnStats>> col_stats_ptrs);
+
+  TableStats(std::vector<std::shared_ptr<ColumnStats>> col_stats_ptrs);
 
   void UpdateNumRows(size_t new_num_rows);
 

--- a/src/optimizer/stats/table_stats.cpp
+++ b/src/optimizer/stats/table_stats.cpp
@@ -17,10 +17,23 @@ namespace peloton {
 namespace optimizer {
 
 TableStats::TableStats(size_t num_rows,
-                       std::vector<std::shared_ptr<ColumnStats>> col_stats_list)
+                       std::vector<std::shared_ptr<ColumnStats>> col_stats_ptrs)
     : num_rows(num_rows) {
-  for (size_t i = 0; i < col_stats_list.size(); ++i) {
-    AddColumnStats(col_stats_list[i]);
+  for (size_t i = 0; i < col_stats_ptrs.size(); ++i) {
+    AddColumnStats(col_stats_ptrs[i]);
+  }
+}
+
+TableStats::TableStats(
+    std::vector<std::shared_ptr<ColumnStats>> col_stats_ptrs) {
+  size_t col_count = col_stats_ptrs.size();
+  for (size_t i = 0; i < col_count; ++i) {
+    AddColumnStats(col_stats_ptrs[i]);
+  }
+  if (col_count == 0) {
+    num_rows = 0;
+  } else {
+    num_rows = col_stats_ptrs[0]->num_rows;
   }
 }
 


### PR DESCRIPTION
This PR adds two interfaces to get tables stats:
1. With `database_id` and `table_id`.
2. With `database_id` and `table_id` and a vector of column ids.